### PR TITLE
fix build with modern Rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:alpine
 LABEL source_repository="https://github.com/databus23/concourse-feed-resource"
 
-RUN gem install --no-rdoc --no-ri concourse-fuselage
+RUN gem install --no-document concourse-fuselage
 ADD resource/ /opt/resource

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:alpine
+LABEL source_repository="https://github.com/databus23/concourse-feed-resource"
 
 RUN gem install --no-rdoc --no-ri concourse-fuselage
 ADD resource/ /opt/resource


### PR DESCRIPTION
Also add the source_repository label that is required for pushing to our Keppel account.